### PR TITLE
Adjust package entrypoints for TypeScript source resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,14 @@
 {
   "name": "quo-client-ts",
   "version": "2.0.0",
-  "main": "index.js",
+  "type": "module",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": {
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
   "scripts": {
     "test": "vitest run",
     "build": "tsc",

--- a/src/request.ts
+++ b/src/request.ts
@@ -7,7 +7,7 @@ const RAW_BASE = process.env.QUO_BASE_URL
 
 export const BASE = RAW_BASE.replace(/\/+$/, '')
 
-export const API_KEY = process.env.QUO_API_KEY ?? process.env.OPENPHONE_API_KEY
+export const API_KEY = process.env.QUO_API_KEY ?? process.env.OPENPHONE_API_KEY ?? ''
 
 if (!API_KEY) {
   throw new Error('Missing API key: set QUO_API_KEY or OPENPHONE_API_KEY')

--- a/tests/entry.test.ts
+++ b/tests/entry.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest'
+
+describe('package entry', () => {
+  it('exports the public API surface', async () => {
+    process.env.QUO_API_KEY = process.env.QUO_API_KEY ?? 'test-key'
+    const entry = await import('../src')
+    expect(entry).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary
- point the package entry to the TypeScript source and add an exports map for deterministic resolution
- add a minimal test to ensure the package entry can be imported when an API key is set
- make the API key constant a guaranteed string while keeping the runtime guard intact

## Testing
- pnpm test
- pnpm build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940d47181bc8326b65ed72e13e2d45e)